### PR TITLE
Check invalid global set

### DIFF
--- a/exec-service-wasmer/src/wasmer_breakpoints.rs
+++ b/exec-service-wasmer/src/wasmer_breakpoints.rs
@@ -12,8 +12,6 @@ use wasmer_types::{GlobalIndex, ModuleInfo};
 const BREAKPOINT_VALUE: &str = "breakpoint_value";
 
 pub(crate) const BREAKPOINT_VALUE_NO_BREAKPOINT: u64 = 0;
-#[allow(dead_code)]
-pub(crate) const BREAKPOINT_VALUE_EXECUTION_FAILED: u64 = 1;
 pub(crate) const BREAKPOINT_VALUE_OUT_OF_GAS: u64 = 4;
 pub(crate) const BREAKPOINT_VALUE_MEMORY_LIMIT: u64 = 5;
 
@@ -135,14 +133,16 @@ impl FunctionMiddleware for FunctionBreakpoints {
         operator: Operator<'b>,
         state: &mut MiddlewareReaderState<'b>,
     ) -> Result<(), MiddlewareError> {
-        if matches!(
+        let must_add_breakpoint = matches!(
             operator,
             Operator::Call { .. } | Operator::CallIndirect { .. }
-        ) {
-            self.inject_breakpoint_condition_check(state)
-        }
+        );
 
         state.push_operator(operator);
+
+        if must_add_breakpoint {
+            self.inject_breakpoint_condition_check(state)
+        }
 
         Ok(())
     }

--- a/exec-service-wasmer/src/wasmer_instance.rs
+++ b/exec-service-wasmer/src/wasmer_instance.rs
@@ -90,18 +90,19 @@ fn push_middlewares(
     // Create breakpoint middelware
     let breakpoints_middleware = Arc::new(Breakpoints::new());
 
-    // Create opcode_control middleware
-    let opcode_control_middleware = Arc::new(OpcodeControl::new(
-        compilation_options.max_memory_grow,
-        compilation_options.max_memory_grow_delta,
-        breakpoints_middleware.clone(),
-    ));
-
     // Create metering middleware
     let metering_middleware = Arc::new(Metering::new(
         compilation_options.gas_limit,
         executor_data.opcode_cost.clone(),
         breakpoints_middleware.clone(),
+    ));
+
+    // Create opcode_control middleware
+    let opcode_control_middleware = Arc::new(OpcodeControl::new(
+        compilation_options.max_memory_grow,
+        compilation_options.max_memory_grow_delta,
+        breakpoints_middleware.clone(),
+        metering_middleware.clone(),
     ));
 
     executor_data.print_execution_info("Adding metering middleware ...");

--- a/exec-service-wasmer/src/wasmer_instance.rs
+++ b/exec-service-wasmer/src/wasmer_instance.rs
@@ -41,6 +41,7 @@ impl WasmerInstance {
 
         executor_data.print_execution_info("Instantiating module ...");
         let wasmer_instance = wasmer::Instance::new(&module, &import_object)?;
+        set_points_limit(&wasmer_instance, compilation_options.gas_limit);
 
         let memory_name = extract_wasmer_memory_name(&wasmer_instance)?;
 
@@ -123,9 +124,10 @@ impl Instance for WasmerInstance {
             .get_function(func_name)
             .map_err(|_| "function not found".to_string())?;
 
-        let _ = func.call(&[]);
-
-        Ok(())
+        match func.call(&[]) {
+            Ok(_) => Ok(()),
+            Err(err) => Err(err.to_string()),
+        }
     }
 
     fn check_signatures(&self) -> bool {

--- a/exec-service-wasmer/src/wasmer_instance.rs
+++ b/exec-service-wasmer/src/wasmer_instance.rs
@@ -87,7 +87,7 @@ fn push_middlewares(
     compilation_options: &CompilationOptions,
     executor_data: Rc<WasmerExecutorData>,
 ) {
-    // Create breakpoint middelware
+    // Create breakpoints middleware
     let breakpoints_middleware = Arc::new(Breakpoints::new());
 
     // Create metering middleware
@@ -102,7 +102,6 @@ fn push_middlewares(
         compilation_options.max_memory_grow,
         compilation_options.max_memory_grow_delta,
         breakpoints_middleware.clone(),
-        metering_middleware.clone(),
     ));
 
     executor_data.print_execution_info("Adding metering middleware ...");

--- a/exec-service-wasmer/src/wasmer_metering.rs
+++ b/exec-service-wasmer/src/wasmer_metering.rs
@@ -41,6 +41,31 @@ impl Metering {
             global_indexes: Mutex::new(None),
         }
     }
+
+    fn get_points_limit_global_index(&self) -> GlobalIndex {
+        self.global_indexes
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .points_limit_global_index
+    }
+
+    fn get_points_used_global_index(&self) -> GlobalIndex {
+        self.global_indexes
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .points_used_global_index
+    }
+
+    pub(crate) fn get_metering_globals_indexes(&self) -> Vec<u32> {
+        vec![
+            self.get_points_limit_global_index().as_u32(),
+            self.get_points_used_global_index().as_u32(),
+        ]
+    }
 }
 
 unsafe impl Send for Metering {}

--- a/exec-service-wasmer/src/wasmer_metering.rs
+++ b/exec-service-wasmer/src/wasmer_metering.rs
@@ -41,31 +41,6 @@ impl Metering {
             global_indexes: Mutex::new(None),
         }
     }
-
-    fn get_points_limit_global_index(&self) -> GlobalIndex {
-        self.global_indexes
-            .lock()
-            .unwrap()
-            .as_ref()
-            .unwrap()
-            .points_limit_global_index
-    }
-
-    fn get_points_used_global_index(&self) -> GlobalIndex {
-        self.global_indexes
-            .lock()
-            .unwrap()
-            .as_ref()
-            .unwrap()
-            .points_used_global_index
-    }
-
-    pub(crate) fn get_metering_globals_indexes(&self) -> Vec<u32> {
-        vec![
-            self.get_points_limit_global_index().as_u32(),
-            self.get_points_used_global_index().as_u32(),
-        ]
-    }
 }
 
 unsafe impl Send for Metering {}
@@ -156,6 +131,21 @@ impl FunctionMetering {
         self.breakpoints_middleware
             .inject_breakpoint_condition(state, BREAKPOINT_VALUE_OUT_OF_GAS);
     }
+
+    fn check_invalid_global_set<'b>(&self, operator: &Operator<'b>) -> Result<(), MiddlewareError> {
+        if let Operator::GlobalSet { global_index } = *operator {
+            if global_index == self.global_indexes.points_limit_global_index.as_u32()
+                || global_index == self.global_indexes.points_used_global_index.as_u32()
+            {
+                return Err(MiddlewareError::new(
+                    "metering_middleware",
+                    "invalid global set",
+                ));
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl FunctionMiddleware for FunctionMetering {
@@ -164,6 +154,9 @@ impl FunctionMiddleware for FunctionMetering {
         operator: Operator<'b>,
         state: &mut MiddlewareReaderState<'b>,
     ) -> Result<(), MiddlewareError> {
+        // Check for invalid access of metering globals
+        self.check_invalid_global_set(&operator)?;
+
         // Get the cost of the current operator, and add it to the accumulator.
         // This needs to be done before the metering logic, to prevent operators like `Call` from escaping metering in some
         // corner cases.

--- a/exec-service-wasmer/src/wasmer_opcode_control.rs
+++ b/exec-service-wasmer/src/wasmer_opcode_control.rs
@@ -181,6 +181,12 @@ impl FunctionOpcodeControl {
                 .get_metering_globals_indexes()
                 .contains(&global_index)
             {
+                println!("invalid global set");
+                println!("global_index {}", global_index);
+                println!(
+                    "metering indexes: {:?}",
+                    self.metering_middleware.get_metering_globals_indexes()
+                );
                 return Err(MiddlewareError::new(
                     "opcode_control_middleware",
                     "invalid global set",

--- a/exec-service-wasmer/src/wasmer_opcode_control.rs
+++ b/exec-service-wasmer/src/wasmer_opcode_control.rs
@@ -10,7 +10,10 @@ use wasmer::{
 };
 use wasmer_types::{GlobalIndex, ModuleInfo};
 
-use crate::wasmer_breakpoints::{Breakpoints, BREAKPOINT_VALUE_MEMORY_LIMIT};
+use crate::{
+    wasmer_breakpoints::{Breakpoints, BREAKPOINT_VALUE_MEMORY_LIMIT},
+    wasmer_metering::Metering,
+};
 
 const OPCODE_CONTROL_MEMORY_GROW_COUNT: &str = "opcode_control_memory_grow_count";
 const OPCODE_CONTROL_OPERAND_BACKUP: &str = "opcode_control_operand_backup";
@@ -26,6 +29,7 @@ pub(crate) struct OpcodeControl {
     max_memory_grow: usize,
     max_memory_grow_delta: usize,
     breakpoints_middleware: Arc<Breakpoints>,
+    metering_middleware: Arc<Metering>,
     global_indexes: Mutex<Option<OpcodeControlGlobalIndexes>>,
 }
 
@@ -34,11 +38,13 @@ impl OpcodeControl {
         max_memory_grow: usize,
         max_memory_grow_delta: usize,
         breakpoints_middleware: Arc<Breakpoints>,
+        metering_middleware: Arc<Metering>,
     ) -> Self {
         Self {
             max_memory_grow,
             max_memory_grow_delta,
             breakpoints_middleware,
+            metering_middleware,
             global_indexes: Mutex::new(None),
         }
     }
@@ -63,6 +69,7 @@ impl ModuleMiddleware for OpcodeControl {
             max_memory_grow: self.max_memory_grow,
             max_memory_grow_delta: self.max_memory_grow_delta,
             breakpoints_middleware: self.breakpoints_middleware.clone(),
+            metering_middleware: self.metering_middleware.clone(),
             global_indexes: self.global_indexes.lock().unwrap().clone().unwrap(),
         })
     }
@@ -101,6 +108,7 @@ struct FunctionOpcodeControl {
     max_memory_grow: usize,
     max_memory_grow_delta: usize,
     breakpoints_middleware: Arc<Breakpoints>,
+    metering_middleware: Arc<Metering>,
     global_indexes: OpcodeControlGlobalIndexes,
 }
 
@@ -146,6 +154,42 @@ impl FunctionOpcodeControl {
         self.breakpoints_middleware
             .inject_breakpoint_condition(state, BREAKPOINT_VALUE_MEMORY_LIMIT);
     }
+
+    fn inject_memory_grow_check<'b>(&self, state: &mut MiddlewareReaderState<'b>) {
+        self.inject_memory_grow_limit_check(state);
+        self.inject_memory_grow_count_increment(state);
+
+        // Backup the top of the stack (the parameter for memory.grow) in order to
+        // duplicate it: once for the comparison against max_memory_grow_delta and
+        // again for memory.grow itself, assuming the comparison passes.
+        state.extend(&[Operator::GlobalSet {
+            global_index: self.global_indexes.operand_backup_global_index.as_u32(),
+        }]);
+
+        self.inject_memory_grow_delta_limit_check(state);
+
+        // Bring back the backed-up operand for memory.grow.
+        state.extend(&[Operator::GlobalGet {
+            global_index: self.global_indexes.operand_backup_global_index.as_u32(),
+        }]);
+    }
+
+    fn check_invalid_global_set<'b>(&self, operator: &Operator<'b>) -> Result<(), MiddlewareError> {
+        if let Operator::GlobalSet { global_index } = operator {
+            if self
+                .metering_middleware
+                .get_metering_globals_indexes()
+                .contains(&global_index)
+            {
+                return Err(MiddlewareError::new(
+                    "opcode_control_middleware",
+                    "invalid global set",
+                ));
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl FunctionMiddleware for FunctionOpcodeControl {
@@ -155,23 +199,10 @@ impl FunctionMiddleware for FunctionOpcodeControl {
         state: &mut MiddlewareReaderState<'b>,
     ) -> Result<(), MiddlewareError> {
         if matches!(operator, Operator::MemoryGrow { .. }) {
-            self.inject_memory_grow_limit_check(state);
-            self.inject_memory_grow_count_increment(state);
-
-            // Backup the top of the stack (the parameter for memory.grow) in order to
-            // duplicate it: once for the comparison against max_memory_grow_delta and
-            // again for memory.grow itself, assuming the comparison passes.
-            state.extend(&[Operator::GlobalSet {
-                global_index: self.global_indexes.operand_backup_global_index.as_u32(),
-            }]);
-
-            self.inject_memory_grow_delta_limit_check(state);
-
-            // Bring back the backed-up operand for memory.grow.
-            state.extend(&[Operator::GlobalGet {
-                global_index: self.global_indexes.operand_backup_global_index.as_u32(),
-            }]);
+            self.inject_memory_grow_check(state);
         }
+
+        self.check_invalid_global_set(&operator)?;
 
         state.push_operator(operator);
 


### PR DESCRIPTION
_PS: `metering` middleware check for invalid `global` set_