### PR TITLE
multiversx-chain-vm-executor-wasmer dependency simplified, feature removed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ members = [
     "vm-executor-experimental",
     "vm-executor-wasmer",
 ]
+
+[patch.crates-io]
+multiversx-chain-vm-executor = { path = "vm-executor" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,7 @@ members = [
 ]
 
 [patch.crates-io]
+# Overrides the `multiversx-chain-vm-executor` dependency to use the local path,
+# for local builds and CI. Required by multiversx-chain-vm-executor-wasmer, which
+# cannot set the path directly without breaking external consumers.
 multiversx-chain-vm-executor = { path = "vm-executor" }

--- a/vm-executor-wasmer/Cargo.toml
+++ b/vm-executor-wasmer/Cargo.toml
@@ -16,20 +16,8 @@ categories = ["cryptography::cryptocurrencies"]
 
 [lib]
 
-[features]
-default = ["multiversx-chain-vm-executor"]
-
 [dependencies.multiversx-chain-vm-executor]
 version = "0.5.1"
-path = "../vm-executor"
-optional = true
-
-## Optional dependency to published interfaces crate,
-## to help with usage as a git-based dependency/
-[dependencies.multiversx-chain-vm-executor-published]
-package = "multiversx-chain-vm-executor"
-version = "0.5.1"
-optional = true
 
 [dependencies]
 wasmer = { git = "https://github.com/multiversx/wasmer", rev = "73f2111abf85700dec4f11fb23ece01abc2065e3", default-features = false, features = [

--- a/vm-executor-wasmer/Cargo.toml
+++ b/vm-executor-wasmer/Cargo.toml
@@ -17,6 +17,9 @@ categories = ["cryptography::cryptocurrencies"]
 [lib]
 
 [dependencies.multiversx-chain-vm-executor]
+# Not setting the path = "../vm-executor" here, because it would break
+# external consumers, which import it via gir revision. The path is overridden
+# in the workspace Cargo.toml via [patch.crates-io].
 version = "0.5.1"
 
 [dependencies]

--- a/vm-executor-wasmer/src/lib.rs
+++ b/vm-executor-wasmer/src/lib.rs
@@ -17,8 +17,4 @@ pub use wasmer_instance::*;
 pub use wasmer_metering_helpers::*;
 pub use wasmer_service::*;
 
-#[cfg(feature = "multiversx-chain-vm-executor")]
 pub use multiversx_chain_vm_executor as executor_interface;
-
-#[cfg(feature = "multiversx-chain-vm-executor-published")]
-pub use multiversx_chain_vm_executor_published as executor_interface;

--- a/vm-executor-wasmer/src/wasmer_instance.rs
+++ b/vm-executor-wasmer/src/wasmer_instance.rs
@@ -268,9 +268,7 @@ impl InstanceLegacy for WasmerInstance {
 
     fn has_imported_function(&self, func_name: &str) -> bool {
         for import in self.wasmer_instance.module().imports() {
-            if let ExternType::Function(_) = import.ty()
-                && import.name() == func_name
-            {
+            if is_imported_function(&import, func_name) {
                 return true;
             }
         }
@@ -373,4 +371,8 @@ impl InstanceLegacy for WasmerInstance {
             Err(err) => Err(err.to_string()),
         }
     }
+}
+
+fn is_imported_function(import: &wasmer::ImportType, func_name: &str) -> bool {
+    matches!(import.ty(), ExternType::Function(_)) && import.name() == func_name
 }


### PR DESCRIPTION
Simplifies working with multiversx-chain-vm-executor (wasmer-prod).

Retained some compatibility with Rust 1.85.