### PR TITLE
wasmer prod instance - set_breakpoint_value_legacy fix

### DIFF
--- a/vm-executor-wasmer/src/new_traits/wasmer_prod_instance_state.rs
+++ b/vm-executor-wasmer/src/new_traits/wasmer_prod_instance_state.rs
@@ -1,7 +1,8 @@
+use multiversx_chain_vm_executor::BreakpointValueLegacy;
+
 use crate::WasmerInstance;
 use crate::executor_interface::{
-    BreakpointValue, ExecutorError, InstanceLegacy, InstanceState, MemLength, MemPtr,
-    VMHooksEarlyExit,
+    ExecutorError, InstanceLegacy, InstanceState, MemLength, MemPtr, VMHooksEarlyExit,
 };
 
 use std::rc::{Rc, Weak};
@@ -24,10 +25,10 @@ impl WasmerProdInstanceState {
             .map_or_else(|| Err(WasmerExecutorError::BadInstancePointer.into()), Ok)
     }
 
-    pub fn set_breakpoint_value_legacy(&self, value: BreakpointValue) {
+    pub fn set_breakpoint_value_legacy(&self, value: BreakpointValueLegacy) {
         self.instance_rc()
             .unwrap()
-            .set_breakpoint_value(value.to_legacy())
+            .set_breakpoint_value(value)
             .expect("set_breakpoint_value_legacy globals error");
     }
 

--- a/vm-executor-wasmer/src/new_traits/wasmer_prod_instance_state.rs
+++ b/vm-executor-wasmer/src/new_traits/wasmer_prod_instance_state.rs
@@ -1,8 +1,7 @@
-use multiversx_chain_vm_executor::BreakpointValueLegacy;
-
 use crate::WasmerInstance;
 use crate::executor_interface::{
-    ExecutorError, InstanceLegacy, InstanceState, MemLength, MemPtr, VMHooksEarlyExit,
+    BreakpointValueLegacy, ExecutorError, InstanceLegacy, InstanceState, MemLength, MemPtr,
+    VMHooksEarlyExit,
 };
 
 use std::rc::{Rc, Weak};

--- a/vm-executor/src/breakpoint_value.rs
+++ b/vm-executor/src/breakpoint_value.rs
@@ -1,3 +1,10 @@
+
+/// Represents the reason why execution of a WASM instance was interrupted.
+///
+/// Used by the legacy executor interface to communicate breakpoint causes
+/// between the WASM runtime and the high-level VM.
+/// 
+/// TODO: move to wasmer-prod, and hide it from the VM implementation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BreakpointValueLegacy {
     /// Lack of a breakpoint


### PR DESCRIPTION
## Pull request overview

Fixes how legacy breakpoint values are set on the Wasmer production instance state by using the legacy breakpoint type directly (instead of converting from the “new” breakpoint type), aligning with the underlying `InstanceLegacy::set_breakpoint_value` API.

**Changes:**
- Update `WasmerProdInstanceState::set_breakpoint_value_legacy` to accept `BreakpointValueLegacy`.
- Pass the legacy value directly to `WasmerInstance::set_breakpoint_value` (remove `to_legacy()` conversion).
- Adjust imports accordingly.

## Compatibility

The `wasmer-prod` crate is not released, it is imported in the Rust VM via git hash. Method `set_breakpoint_value_legacy` is only used there. See https://github.com/multiversx/mx-sdk-rs/pull/2348